### PR TITLE
Fix error linking against gstreamer 1.15.2 on MacOS.

### DIFF
--- a/addon_config.mk
+++ b/addon_config.mk
@@ -110,6 +110,7 @@ android/armeabi-v7a:
 
 osx:
 	ADDON_LDFLAGS = -F/Library/Frameworks -framework GStreamer
+	ADDON_LDFLAGS += -L/Library/Frameworks/GStreamer.framework/Libraries
 	ADDON_INCLUDES += /Library/Frameworks/GStreamer.framework/Headers
 	ADDON_SOURCES += $(OF_ROOT)/libs/openFrameworks/video/ofGstUtils.h
 	ADDON_SOURCES += $(OF_ROOT)/libs/openFrameworks/video/ofGstUtils.cpp


### PR DESCRIPTION
As described in #23.